### PR TITLE
Print command aliases in docs

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -29,6 +29,16 @@ import (
 
 const markdownExtension = ".md"
 
+func printAliases(buf *bytes.Buffer, cmd *cobra.Command) {
+	if len(cmd.Aliases) > 0 {
+		buf.WriteString("### Aliases\n\n")
+		for _, alias := range cmd.Aliases {
+			buf.WriteString(fmt.Sprintf("* `%s`\n", alias))
+		}
+		buf.WriteString("\n")
+	}
+}
+
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)

--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -29,16 +29,6 @@ import (
 
 const markdownExtension = ".md"
 
-func printAliases(buf *bytes.Buffer, cmd *cobra.Command) {
-	if len(cmd.Aliases) > 0 {
-		buf.WriteString("### Aliases\n\n")
-		for _, alias := range cmd.Aliases {
-			buf.WriteString(fmt.Sprintf("* `%s`\n", alias))
-		}
-		buf.WriteString("\n")
-	}
-}
-
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
@@ -80,6 +70,14 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 
 	if cmd.Runnable() {
 		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.UseLine()))
+	}
+
+	if len(cmd.Aliases) > 0 {
+		buf.WriteString("### Aliases\n\n")
+		for _, alias := range cmd.Aliases {
+			buf.WriteString(fmt.Sprintf("* `%s`\n", alias))
+		}
+		buf.WriteString("\n")
 	}
 
 	if len(cmd.Example) > 0 {

--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -73,12 +73,12 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	}
 
 	if len(cmd.Aliases) > 0 {
-		buf.WriteString("### Aliases\n\n")
+		buf.WriteString("Aliases: ")
 		for _, alias := range cmd.Aliases {
-			if cmd.HasParent() {
-				alias = cmd.Parent().CommandPath() + " " + alias
+			buf.WriteString(fmt.Sprintf("`%s`", alias))
+			if alias != cmd.Aliases[len(cmd.Aliases)-1] {
+				buf.WriteString(", ")
 			}
-			buf.WriteString(fmt.Sprintf("```\n%s\n```\n", alias))
 		}
 		buf.WriteString("\n")
 	}

--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -75,7 +75,10 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	if len(cmd.Aliases) > 0 {
 		buf.WriteString("### Aliases\n\n")
 		for _, alias := range cmd.Aliases {
-			buf.WriteString(fmt.Sprintf("* `%s`\n", alias))
+			if cmd.HasParent() {
+				alias = cmd.Parent().CommandPath() + " " + alias
+			}
+			buf.WriteString(fmt.Sprintf("```\n%s\n```\n", alias))
 		}
 		buf.WriteString("\n")
 	}


### PR DESCRIPTION
Prints the aliases of a command in the markdown of docs